### PR TITLE
Remove opacity for position indicator

### DIFF
--- a/src/app/carousel/carousel.component.scss
+++ b/src/app/carousel/carousel.component.scss
@@ -82,7 +82,6 @@
 /* style the position indicator */
 .position-container {
   position: absolute;
-  background-color: transparent;
   padding: 0.5em;
   font-weight: bold;
   user-select: none;
@@ -91,13 +90,11 @@
 }
 
 .position {
-  background: white;
+  background: gray;
   height: 0.5em;
   width: 0.5em;
-  opacity: 50%;
   border-radius: 1em;
 }
-
 .selected {
-  opacity: 100%;
+  background: white;
 }


### PR DESCRIPTION
Opacity properties were interfering with the position indicator display with production builds.  Removed opacity and added background properties.